### PR TITLE
ConfigFetcher interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ce4cfa8aa3eb29f45e7ba341fdeac9820969e663181e81bddfc4a3aa2d5169bb"
+  inputs-digest = "701c07dbbbabb2137a2e5e94b6fafcf710ca331a5ccb71e8cdd4b8236ce0b0bc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -7,16 +7,13 @@ import (
 	"os"
 
 	"go.bourbon.stream/go-vanityurls-apex/handler"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func main() {
-	configPath := "vanity.yaml"
 	addr := ":" + os.Getenv("PORT")
-	vanity, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	h, err := handler.NewHandler(vanity)
+
+	h, err := handler.NewHandler(fileFetcher{path: "vanity.yaml"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -24,4 +21,23 @@ func main() {
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatal(err)
 	}
+}
+
+type fileFetcher struct {
+	path string
+}
+
+func (ff fileFetcher) Fetch() (*handler.Config, error) {
+	var config *handler.Config
+
+	vanity, err := ioutil.ReadFile(ff.path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal(vanity, &config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/chiefy/go-vanityurls-apex/handler"
+	"go.bourbon.stream/go-vanityurls-apex/handler"
 )
 
 func main() {


### PR DESCRIPTION
Now the `NewHandler()` accepts a `ConfigFetcher` interface so you can define how and where you want to pull the config from. `main.go` defines its own for a local disk, but  you can easily add another for pulling from S3 or somewhere else. It doesn't even have to be YAML either as long as the interface is satisfied.